### PR TITLE
Add seasons

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,3 +27,5 @@ DATABASE_PORT=5800
 # used in get_prod_data script
 # PROD_API_URL="http://uwbadminton.live/api/"
 PROD_API_URL=https://baddie-match.herokuapp.com/api/
+
+REACT_APP_DOMAIN_NAME=http://127.0.0.1:5000/api

--- a/app/routes.py
+++ b/app/routes.py
@@ -142,8 +142,7 @@ def getMatchPage():
         recordsPerPage = int(request.args.get('perPage') or 10)
         start = request.args.get('start', default = "2020-09-01", type = Matches.toDate)
         end = request.args.get('end', default = "2023-09-01", type = Matches.toDate)
-        matches = Matches.query.filter(Matches.date_added <= end).filter(Matches.date_added >= start)
-        # matches = Matches.query.all()
+        matches = Matches.getMatchesBetweenDate(start, end)
 
         matches = matches[::-1]
         matchPage = matches[(page-1)*recordsPerPage:page*recordsPerPage]
@@ -238,7 +237,9 @@ def addMatch():
 @ app.route("/api/players/stats", methods=["GET"])
 def getAllWinPercentages():
     try:
-        return(Stats.getWinPercentages())
+        start = request.args.get('start', default = "2020-09-01", type = Matches.toDate)
+        end = request.args.get('end', default = "2023-09-01", type = Matches.toDate)
+        return(Stats.getWinPercentages(start, end))
     except Exception as e:
         return str(e), 500
 
@@ -251,7 +252,9 @@ def getAllWinPercentages():
 @ app.route("/api/elo/singles", methods=["GET"])
 def getSinglesElo():
     try:
-        return(Player_elo.get_singles_elo())
+        start = request.args.get('start', default = "2020-09-01", type = Matches.toDate)
+        end = request.args.get('end', default = "2023-09-01", type = Matches.toDate)
+        return(Player_elo.get_singles_elo(start, end))
     except Exception as e:
         return str(e), 500
 
@@ -260,7 +263,9 @@ def getSinglesElo():
 @ app.route("/api/elo/doubles", methods=["GET"])
 def getDoublesElo():
     try:
-        return(Player_elo.get_doubles_elo())
+        start = request.args.get('start', default = "2020-09-01", type = Matches.toDate)
+        end = request.args.get('end', default = "2023-09-01", type = Matches.toDate)
+        return(Player_elo.get_doubles_elo(start, end))
     except Exception as e:
         return str(e), 500
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,6 +9,7 @@ import json
 from app.main import db, app
 
 
+
 @cross_origin()
 @app.route("/")
 def serve():
@@ -131,6 +132,7 @@ def getMatches():
     return json.dumps([m.serialize() for m in matches]), 200
 
 
+
 @cross_origin
 @app.route('/api/matches', methods=['GET'])
 def getMatchPage():
@@ -138,7 +140,11 @@ def getMatchPage():
         # app.logger.debug('hit match pagination')
         page = int(request.args.get('page') or 1)
         recordsPerPage = int(request.args.get('perPage') or 10)
-        matches = Matches.query.all()
+        start = request.args.get('start', default = "2020-09-01", type = Matches.toDate)
+        end = request.args.get('end', default = "2023-09-01", type = Matches.toDate)
+        matches = Matches.query.filter(Matches.date_added <= end).filter(Matches.date_added >= start)
+        # matches = Matches.query.all()
+
         matches = matches[::-1]
         matchPage = matches[(page-1)*recordsPerPage:page*recordsPerPage]
         returnObj = {

--- a/app/scripts/add_prod_data.py
+++ b/app/scripts/add_prod_data.py
@@ -30,7 +30,7 @@ def add_players():
               player['first_name'] + " " + player['last_name'])
         player = Players(
             id=player['id'],
-            first_name="test_" + player['first_name'],
+            first_name="t_" + player['first_name'],
             last_name=player['last_name'],
             elegible_year=player['elegible_year'],
             sex=player['sex'],
@@ -103,7 +103,7 @@ def add_categories():
         print("queuing category id: " + str(cat['id']) + " " + cat['name'])
         cat = Categories(
             id=cat['id'],
-            name="test_" + cat['name'],
+            name="t_" + cat['name'],
         )
         db.session.add(cat)
         categories_added += 1

--- a/app/src/matches.py
+++ b/app/src/matches.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from flask_sqlalchemy import SQLAlchemy
 
 from app.main import app
+import datetime
 
 db = SQLAlchemy(app)
 
@@ -74,6 +75,9 @@ class Matches(db.Model):
         if (playerId == id):
           to_return.append(match)
     return json.dumps([m.serialize() for m in to_return])
+  
+  def toDate(dateString): 
+    return datetime.datetime.strptime(dateString, "%Y-%m-%d").date()
 
 
   def createMatch(event, playersInMatch, score, category):

--- a/app/src/matches.py
+++ b/app/src/matches.py
@@ -76,7 +76,7 @@ class Matches(db.Model):
     return json.dumps([m.serialize() for m in to_return])
   
   def toDate(dateString): 
-    return datetime.datetime.strptime(dateString, "%Y-%m-%d").date()
+    return datetime.strptime(dateString, "%Y-%m-%d").date()
   
   def getMatchesBetweenDate(start, end):
     return Matches.query.filter(Matches.date_added <= end).filter(Matches.date_added >= start)

--- a/app/src/matches.py
+++ b/app/src/matches.py
@@ -66,9 +66,9 @@ class Matches(db.Model):
     db.session.commit()
 
 
-  def getMatchesWithPlayer(id):
+  def getMatchesWithPlayer(id, start, end):
     id = int(id)
-    all_matches = Matches.query.all()
+    all_matches = Matches.getMatchesBetweenDate(start, end)
     to_return = []
     for match in all_matches:
       for playerId in match.players:
@@ -78,6 +78,9 @@ class Matches(db.Model):
   
   def toDate(dateString): 
     return datetime.datetime.strptime(dateString, "%Y-%m-%d").date()
+  
+  def getMatchesBetweenDate(start, end):
+    return Matches.query.filter(Matches.date_added <= end).filter(Matches.date_added >= start)
 
 
   def createMatch(event, playersInMatch, score, category):

--- a/app/src/matches.py
+++ b/app/src/matches.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from flask_sqlalchemy import SQLAlchemy
 
 from app.main import app
-import datetime
 
 db = SQLAlchemy(app)
 

--- a/app/src/player_elo.py
+++ b/app/src/player_elo.py
@@ -158,9 +158,9 @@ class Player_elo:
 
             return (player_stats)
 
-    def get_df_stats():
+    def get_df_stats(start, end):
         players = json.loads(Players.get_all_players())
-        all_matches = Matches.query.all()
+        all_matches = Matches.getMatchesBetweenDate(start, end)
     
         matches = json.dumps([m.serialize() for m in all_matches])
         matches = json.loads(matches)
@@ -183,16 +183,16 @@ class Player_elo:
         df_player_stats = pd.DataFrame.from_dict(player_stats, orient='index', dtype=None, columns=stat_columns)
         return df_player_stats
 
-    def get_doubles_elo():
-        df_player_stats = Player_elo.get_df_stats()
+    def get_doubles_elo(start, end):
+        df_player_stats = Player_elo.get_df_stats(start, end)
         df_doubles_ranks = df_player_stats[df_player_stats['doubles_games_played'] >= 1]
         df_doubles_ranks['doubles_win_pct'] =  df_doubles_ranks['doubles_wins']/df_doubles_ranks['doubles_games_played']
         df_doubles_ranks = df_doubles_ranks.sort_values(by=['doubles_rating'], ascending = False)
         df_doubles_ranks = df_doubles_ranks[['name', 'doubles_rating', 'doubles_games_played', 'doubles_wins', 'doubles_losses', 'doubles_win_pct']]
         return df_doubles_ranks.to_json(None, 'records'), 200
 
-    def get_singles_elo():
-        df_player_stats = Player_elo.get_df_stats()
+    def get_singles_elo(start, end):
+        df_player_stats = Player_elo.get_df_stats(start, end)
         df_singles_ranks = df_player_stats[df_player_stats['singles_games_played'] >= 1]
         df_singles_ranks['singles_win_pct'] =  df_singles_ranks['singles_wins']/df_singles_ranks['singles_games_played']
         df_singles_ranks = df_singles_ranks.sort_values(by=['singles_elo'], ascending = False)

--- a/app/src/player_elo.py
+++ b/app/src/player_elo.py
@@ -168,7 +168,7 @@ class Player_elo:
         player_stats = Player_elo.initialize_player_stat_dict(players)
         
         # get recent matches
-        matches = [match for match in matches if datetime.datetime.strptime(match['date_added'], '%Y-%m-%d-%H:%M:%S') > datetime.datetime(2022, 9, 1)]
+        # matches = [match for match in matches if datetime.datetime.strptime(match['date_added'], '%Y-%m-%d-%H:%M:%S') > datetime.datetime(2022, 9, 1)]
         # get sorted matches
         matches = sorted(matches, key=itemgetter('date_added'), reverse=False)
 
@@ -185,7 +185,7 @@ class Player_elo:
 
     def get_doubles_elo(start, end):
         df_player_stats = Player_elo.get_df_stats(start, end)
-        df_doubles_ranks = df_player_stats[df_player_stats['doubles_games_played'] >= 1]
+        df_doubles_ranks = df_player_stats
         df_doubles_ranks['doubles_win_pct'] =  df_doubles_ranks['doubles_wins']/df_doubles_ranks['doubles_games_played']
         df_doubles_ranks = df_doubles_ranks.sort_values(by=['doubles_rating'], ascending = False)
         df_doubles_ranks = df_doubles_ranks[['name', 'doubles_rating', 'doubles_games_played', 'doubles_wins', 'doubles_losses', 'doubles_win_pct']]
@@ -193,7 +193,7 @@ class Player_elo:
 
     def get_singles_elo(start, end):
         df_player_stats = Player_elo.get_df_stats(start, end)
-        df_singles_ranks = df_player_stats[df_player_stats['singles_games_played'] >= 1]
+        df_singles_ranks = df_player_stats
         df_singles_ranks['singles_win_pct'] =  df_singles_ranks['singles_wins']/df_singles_ranks['singles_games_played']
         df_singles_ranks = df_singles_ranks.sort_values(by=['singles_elo'], ascending = False)
         df_singles_ranks = df_singles_ranks[['name', 'singles_elo', 'singles_rating', 'singles_games_played', 'singles_wins', 'singles_losses', 'singles_win_pct']]

--- a/app/src/stats.py
+++ b/app/src/stats.py
@@ -3,11 +3,11 @@ from app.src.matches import Matches
 import json
 
 class Stats:
-    def getWinPercentages():
+    def getWinPercentages(start, end):
         player_results = []
         players = json.loads(Players.get_all_players())
         for p in players:
-            matches = json.loads(Matches.getMatchesWithPlayer(p["id"]))
+            matches = json.loads(Matches.getMatchesWithPlayer(p["id"], start, end))
             d_win, s_win, m_win = 0, 0, 0
             d_loss, s_loss, m_loss = 0, 0, 0
 

--- a/docker-dev.yml
+++ b/docker-dev.yml
@@ -52,7 +52,7 @@ services:
     working_dir: /user/src/app
     command: npm run dev2
     environment:
-      - REACT_APP_DOMAIN_NAME=http://127.0.0.1:5000/api
+      - REACT_APP_DOMAIN_NAME=${REACT_APP_DOMAIN_NAME}
     ports:
       - '8000:3000'
     stdin_open: true

--- a/front-end/src/API/API.js
+++ b/front-end/src/API/API.js
@@ -9,6 +9,6 @@ export const PlayerIdUrl = (id) => `${DomainName}/player/${id}`
 export const CategoryId = (id) => `${DomainName}/category/${id}`
 export const CreatePlayerUrl = `${DomainName}/player`;
 export const GetStatsUrl = `${DomainName}/players/stats`
-export const EloUrl = (event) => `${DomainName}/elo/${event}`
+export const EloUrl = (event, start, end) => `${DomainName}/elo/${event}?start=${start}&end=${end}`
 export const MatchPageUrl = (page, perPage,start,end) => `${DomainName}/matches?page=${page}&perPage=${perPage}&start=${start}&end=${end}`
 export const GetMatchesCount = `${DomainName}/matches/count`

--- a/front-end/src/API/API.js
+++ b/front-end/src/API/API.js
@@ -8,7 +8,7 @@ export const PlayerMatchesUrl = (id) => `${DomainName}/match/player/${id}`
 export const PlayerIdUrl = (id) => `${DomainName}/player/${id}`
 export const CategoryId = (id) => `${DomainName}/category/${id}`
 export const CreatePlayerUrl = `${DomainName}/player`;
-export const GetStatsUrl = `${DomainName}/players/stats`
+export const GetStatsUrl = (start, end) => `${DomainName}/players/stats?start=${start}&end=${end}`
 export const EloUrl = (event, start, end) => `${DomainName}/elo/${event}?start=${start}&end=${end}`
 export const MatchPageUrl = (page, perPage,start,end) => `${DomainName}/matches?page=${page}&perPage=${perPage}&start=${start}&end=${end}`
 export const GetMatchesCount = `${DomainName}/matches/count`

--- a/front-end/src/API/API.js
+++ b/front-end/src/API/API.js
@@ -10,5 +10,5 @@ export const CategoryId = (id) => `${DomainName}/category/${id}`
 export const CreatePlayerUrl = `${DomainName}/player`;
 export const GetStatsUrl = `${DomainName}/players/stats`
 export const EloUrl = (event) => `${DomainName}/elo/${event}`
-export const MatchPageUrl = (page, perPage) => `${DomainName}/matches?page=${page}&perPage=${perPage}`
+export const MatchPageUrl = (page, perPage,start,end) => `${DomainName}/matches?page=${page}&perPage=${perPage}&start=${start}&end=${end}`
 export const GetMatchesCount = `${DomainName}/matches/count`

--- a/front-end/src/Contexts/AppContext.js
+++ b/front-end/src/Contexts/AppContext.js
@@ -31,50 +31,14 @@ const useApp = () => {
             .then(response => response.json())
             .then(data => { setCategories(data) })
 
-        getStats('singles');
-        getStats('doubles');
-        getStats('mixed');
+        // getStats('singles');
+        // getStats('doubles');
+        // getStats('mixed');
 
 
         getElo('singles');
         getElo('doubles');
     }, []);
-
-    const getStats = (category) => {
-        queryStats()
-            .then(data => data.map(s => {
-                let percentage = 0;
-                let category_wins = category + '_wins';
-                let category_losses = category + '_losses';
-                if (s[category_wins] + s[category_losses] != 0) {
-                    percentage = Math.round((s[category_wins] / (s[category_wins] + s[category_losses])) * 100);
-                }
-                return {
-                    name: s.name,
-                    percentage: percentage,
-                    wins: s[category_wins],
-                    losses: s[category_losses],
-                }
-            }))
-            .then(results => {
-                var items = Object.keys(results).map(function (key) {
-                    return [key, results[key]];
-                });
-                items.sort(function (first, second) {
-                    return second[1].percentage - first[1].percentage;
-                });
-                return items;
-            })
-            .then(res => {
-                if (category === 'singles') {
-                    setSinglesRankings(res)
-                } else if (category === 'doubles') {
-                    setDoublesRankings(res)
-                } else {
-                    setMixedRankings(res)
-                }
-            })
-    };
 
     const getElo = (event,start,end) => {
         queryElo(event,start,end)
@@ -96,7 +60,7 @@ const useApp = () => {
 
     const queryCategory = (id) => fetch(CategoryId, { method: 'GET' }).then(response => response.json())
 
-    const queryStats = () => fetch(GetStatsUrl, { method: 'GET' }).then(response => response.json())
+    const queryStats = (start, end) => fetch(GetStatsUrl(start, end), { method: 'GET' }).then(response => response.json())
 
     const queryElo = (event, start, end) => fetch(EloUrl(event, start, end), { method: 'GET' }).then(response => response.json())
 

--- a/front-end/src/Contexts/AppContext.js
+++ b/front-end/src/Contexts/AppContext.js
@@ -76,8 +76,8 @@ const useApp = () => {
             })
     };
 
-    const getElo = (event) => {
-        queryElo(event)
+    const getElo = (event,start,end) => {
+        queryElo(event,start,end)
             .then(data => {
                 if (event === 'singles') {
                     setSinglesElo(data);
@@ -98,7 +98,7 @@ const useApp = () => {
 
     const queryStats = () => fetch(GetStatsUrl, { method: 'GET' }).then(response => response.json())
 
-    const queryElo = (event) => fetch(EloUrl(event), { method: 'GET' }).then(response => response.json())
+    const queryElo = (event, start, end) => fetch(EloUrl(event, start, end), { method: 'GET' }).then(response => response.json())
 
     const queryMatchPage = (id, perPage, start, end) => fetch(MatchPageUrl(id, perPage, start, end), { method: 'GET' }).then(response => response.json())
 

--- a/front-end/src/Contexts/AppContext.js
+++ b/front-end/src/Contexts/AppContext.js
@@ -100,7 +100,7 @@ const useApp = () => {
 
     const queryElo = (event) => fetch(EloUrl(event), { method: 'GET' }).then(response => response.json())
 
-    const queryMatchPage = (id, perPage) => fetch(MatchPageUrl(id, perPage), { method: 'GET' }).then(response => response.json())
+    const queryMatchPage = (id, perPage, start, end) => fetch(MatchPageUrl(id, perPage, start, end), { method: 'GET' }).then(response => response.json())
 
     return {
         //constants across app

--- a/front-end/src/components/EloPage.js
+++ b/front-end/src/components/EloPage.js
@@ -15,10 +15,10 @@ const EloPage = () => {
 
 
 
-    useEffect(() => {
-        queryThenFormatSinglesElo('2023-09-01', '2024-08-31')
-        queryThenFormatDoublesElo('2023-09-01', '2024-08-31')
-    }, [])
+    // useEffect(() => {
+    //     queryThenFormatSinglesElo('2023-09-01', '2024-08-31')
+    //     queryThenFormatDoublesElo('2023-09-01', '2024-08-31')
+    // }, [])
 
     const queryThenFormatSinglesElo = (newSeasonStart, newSeasonEnd) => {
         queryElo('singles', newSeasonStart, newSeasonEnd).then(data => {

--- a/front-end/src/components/EloPage.js
+++ b/front-end/src/components/EloPage.js
@@ -1,10 +1,43 @@
 import { Container, Row, Col, ListGroup } from "react-bootstrap";
-import { useContext } from "react";
-import { AppContext } from "../Contexts/AppContext";
+import { useContext, useEffect, useState } from "react";
+import { AppContext, AppContextProvider } from "../Contexts/AppContext";
+import SeasonSelector from "./SeasonSelector";
+
+
 
 
 const EloPage = () => {
-    const { singlesElo, doublesElo } = useContext(AppContext);
+    const { queryElo, players } = useContext(AppContext);
+    const [seasonStart, setSeasonStart] = useState('2023-09-01');
+    const [seasonEnd, setSeasonEnd] = useState('2024-08-31');
+    const [singlesElo, setSinglesElo] = useState([]);
+    const [doublesElo, setDoublesElo] = useState([]);
+
+
+
+    useEffect(() => {
+        queryThenFormatSinglesElo('2023-09-01', '2024-08-31')
+        queryThenFormatDoublesElo('2023-09-01', '2024-08-31')
+    }, [])
+
+    const queryThenFormatSinglesElo = (newSeasonStart, newSeasonEnd) => {
+        queryElo('singles', newSeasonStart, newSeasonEnd).then(data => {
+            setSinglesElo(data)
+        })
+    }
+
+    const queryThenFormatDoublesElo = (newSeasonStart, newSeasonEnd) => {
+        queryElo('doubles', newSeasonStart, newSeasonEnd).then(data => {
+            setDoublesElo(data)
+        })
+    }
+
+    useEffect(() => {
+        queryThenFormatSinglesElo(seasonStart, seasonEnd);
+        queryThenFormatDoublesElo(seasonStart, seasonEnd);
+    }, [seasonStart, seasonEnd])
+
+
 
     const doubles = (elo) => {
         elo.map((player) => {
@@ -14,15 +47,10 @@ const EloPage = () => {
         elo.sort((a, b) => {
             return b['mu'] - a['mu']
         })
-        elo.map((player) => {
-            // (player['name'])
-        })
-        
+
         const result = elo.filter((player) => {
             return player.doubles_games_played > 8 && player.sigma < 3;
         })
-        
-       
 
 
         let i = 0
@@ -55,7 +83,7 @@ const EloPage = () => {
         })
 
         const result = elo.filter((player) => {
-            return player.singles_games_played > 8 && player.sigma < 3;
+            return player.singles_games_played > 5 && player.sigma < 43;
         })
 
         let i = 0
@@ -83,7 +111,11 @@ const EloPage = () => {
                 <Row className="page-title">
                     Current Elo Rankings:
                 </Row>
-                {(singlesElo.length == 0 || doublesElo.length == 0) ? (
+                <SeasonSelector
+                    setStart={(start) => setSeasonStart(start)}
+                    setEnd={(end) => setSeasonEnd(end)}
+                />
+                {(singlesElo.length == 0 || doublesElo.length == 0 || players.length == 0) ? (
                     <Col className='page-title'>
                         Retreiving data, please be patient...
                     </Col>

--- a/front-end/src/components/EloPage.js
+++ b/front-end/src/components/EloPage.js
@@ -49,7 +49,7 @@ const EloPage = () => {
         })
 
         const result = elo.filter((player) => {
-            return player.doubles_games_played > 8 && player.sigma < 3;
+            return player.doubles_games_played > 5 && player.sigma < 4;
         })
 
 
@@ -83,7 +83,7 @@ const EloPage = () => {
         })
 
         const result = elo.filter((player) => {
-            return player.singles_games_played > 5 && player.sigma < 43;
+            return player.singles_games_played > 5 && player.sigma < 4;
         })
 
         let i = 0

--- a/front-end/src/components/LandingPage.js
+++ b/front-end/src/components/LandingPage.js
@@ -1,22 +1,76 @@
 import { Container, Row, Col, ListGroup } from "react-bootstrap";
-import { useContext } from "react";
+import { useState, useEffect, useContext } from "react"
 import { AppContext } from "../Contexts/AppContext";
+import SeasonSelector from "./SeasonSelector";
 
 const LandingPage = () => {
-    const { singlesRankings, doublesRankings, mixedRankings} = useContext(AppContext);
+    const { queryStats } = useContext(AppContext);
+    const [stats, setStats] = useState([]);
+    const [singlesRankings, setSinglesRankings] = useState([]);
+    const [doublesRankings, setDoublesRankings] = useState([]);
+    const [mixedRankings, setMixedRankings] = useState([]);
+    const [seasonStart, setSeasonStart] = useState('2023-09-01');
+    const [seasonEnd, setSeasonEnd] = useState('2024-08-31');
+
+    const getStats = (newSeasonStart, newSeasonEnd) => {
+        queryStats(newSeasonStart, newSeasonEnd).then(data => {
+            setStats(data)
+        })
+    }
+
+    const updateStats = (category, newStats) => {
+        var results = newStats.map(s => {
+            let percentage = 0;
+            let category_wins = category + '_wins';
+            let category_losses = category + '_losses';
+            if (s[category_wins] + s[category_losses] != 0) {
+                percentage = Math.round((s[category_wins] / (s[category_wins] + s[category_losses])) * 100);
+            }
+            return {
+                name: s.name,
+                percentage: percentage,
+                wins: s[category_wins],
+                losses: s[category_losses],
+            }
+
+        })
+        var items = Object.keys(results).map(function (key) {
+            return [key, results[key]];
+        });
+        items.sort(function (first, second) {
+            return second[1].percentage - first[1].percentage;
+        });
+        if (category === 'singles') {
+            setSinglesRankings(items)
+        } else if (category === 'doubles') {
+            setDoublesRankings(items)
+        } else {
+            setMixedRankings(items)
+        }
+    }
+
+    useEffect(() => {
+        getStats(seasonStart, seasonEnd);
+    }, [seasonStart, seasonEnd])
+
+    useEffect(() => {
+        updateStats('singles', stats);
+        updateStats('doubles', stats);
+        updateStats('mixed', stats);
+    }, [stats])
 
     const Rankings = (event) => {
         return <ListGroup as="ol" numbered>
-            { event.filter(r => r[1].wins + r[1].losses > 4).slice(0,10).map((r, i) => {
+            {event.filter(r => r[1].wins + r[1].losses > 4).slice(0, 10).map((r, i) => {
                 return <ListGroup.Item>
-                            <Row>
-                                <Col xs={6}>{i+1}. {r[1].name}</Col>
-                                <Col xs={6}>{r[1].percentage}% (W: {r[1].wins}, L: {r[1].losses})</Col>
-                            </Row>
-                        </ListGroup.Item>
-                })
+                    <Row>
+                        <Col xs={6}>{i + 1}. {r[1].name}</Col>
+                        <Col xs={6}>{r[1].percentage}% (W: {r[1].wins}, L: {r[1].losses})</Col>
+                    </Row>
+                </ListGroup.Item>
+            })
             }
-            </ListGroup>
+        </ListGroup>
     }
 
     return (
@@ -25,6 +79,10 @@ const LandingPage = () => {
                 <Row className="page-title">
                     Welcome to the official site of the Waterloo Warriors Varsity Badminton Team Statistics!
                 </Row>
+                <SeasonSelector
+                    setStart={(start) => setSeasonStart(start)}
+                    setEnd={(end) => setSeasonEnd(end)}
+                />
                 <Row className="page-title">
                     Current Rankings By Win %:
                 </Row>
@@ -32,15 +90,15 @@ const LandingPage = () => {
                     <Row>
                         <Col sm={12} md={6} >
                             <div className='table-header'>Singles Rankings</div>
-                            { Rankings(singlesRankings) }
+                            {Rankings(singlesRankings)}
                         </Col>
                         <Col sm={12} md={6} >
                             <div className='table-header'>Doubles Rankings</div>
-                            { Rankings(doublesRankings) }
+                            {Rankings(doublesRankings)}
                         </Col>
                         <Col sm={12} md={6} >
                             <div className='table-header'>Mixed Rankings</div>
-                            { Rankings(mixedRankings) }
+                            {Rankings(mixedRankings)}
                         </Col>
                     </Row>
                 </Container>

--- a/front-end/src/components/Results.js
+++ b/front-end/src/components/Results.js
@@ -20,7 +20,6 @@ const ResultsPage = () => {
  
 
     function queryThenFormatMatches(newActivePage, newRecordsPerPage, newSeasonStart, newSeasonEnd) {
-        console.log(newSeasonEnd, newSeasonEnd)
         queryMatchPage(newActivePage, newRecordsPerPage, newSeasonStart, newSeasonEnd)
             .then(data => {
                 var matchesDict = {};
@@ -121,8 +120,12 @@ const ResultsPage = () => {
                     <Col className='page-title'>
                         RESULTS
                     </Col>
-                </Row>
-                <Row>
+
+                <SeasonSelector 
+                        setStart = {(start) => setSeasonStart(start)}
+                        setEnd = {(end) => setSeasonEnd(end)}
+                    />
+
                     <Col className='pagination'>
                         <PaginationControl
                             page={activePage}
@@ -159,10 +162,7 @@ const ResultsPage = () => {
                     </Col>
                 </Row>
                 <Row>
-                    <SeasonSelector 
-                        setStart = {(start) => setSeasonStart(start)}
-                        setEnd = {(end) => setSeasonEnd(end)}
-                    />
+                    
                 </Row>
                 {matches.length == 0 || players.length == 0 ? (
                     /* if no matches yet or if there are matches but no players */

--- a/front-end/src/components/Results.js
+++ b/front-end/src/components/Results.js
@@ -4,6 +4,7 @@ import { AppContext } from "../Contexts/AppContext";
 import { GetMatchesCount } from "../API/API"
 import Moment from "moment"
 import { PaginationControl } from 'react-bootstrap-pagination-control';
+import  SeasonSelector from "./SeasonSelector"
 
 const ResultsPage = () => {
     // const [results, setResults] = useState({});
@@ -13,11 +14,14 @@ const ResultsPage = () => {
     const [recordCount, setRecordCount] = useState(0);
     const [pageCount, setPageCount] = useState(0);
     const [activePage, setActivePage] = useState(1);
-    const [recordsPerPage, setRecordsPerPage] = useState(10)
+    const [recordsPerPage, setRecordsPerPage] = useState(10);
+    const [seasonStart, setSeasonStart] = useState('2023-09-01');
+    const [seasonEnd, setSeasonEnd] = useState('2024-08-31');
+ 
 
-
-    function queryThenFormatMatches(newActivePage, newRecordsPerPage) {
-        queryMatchPage(newActivePage, newRecordsPerPage)
+    function queryThenFormatMatches(newActivePage, newRecordsPerPage, newSeasonStart, newSeasonEnd) {
+        console.log(newSeasonEnd, newSeasonEnd)
+        queryMatchPage(newActivePage, newRecordsPerPage, newSeasonStart, newSeasonEnd)
             .then(data => {
                 var matchesDict = {};
                 data.records.forEach((d) => {
@@ -45,12 +49,12 @@ const ResultsPage = () => {
     }
 
     useEffect(() => {
-        queryThenFormatMatches(1, 10)
+        queryThenFormatMatches(1, 10, '2023-09-01', '2024-08-31')
     }, [])
 
     useEffect(() => {
-        queryThenFormatMatches(activePage, recordsPerPage)
-    }, [activePage, recordsPerPage])
+        queryThenFormatMatches(activePage, recordsPerPage, seasonStart, seasonEnd)
+    }, [activePage, recordsPerPage, seasonStart, seasonEnd])
 
     // TODO: someone with React experience pls do this better
     function formatPlayerSingles(match, index) {
@@ -112,6 +116,7 @@ const ResultsPage = () => {
     return (
         <>
             <Container>
+                
                 <Row >
                     <Col className='page-title'>
                         RESULTS
@@ -152,6 +157,12 @@ const ResultsPage = () => {
                             }}>20</Dropdown.Item>
                         </DropdownButton>
                     </Col>
+                </Row>
+                <Row>
+                    <SeasonSelector 
+                        setStart = {(start) => setSeasonStart(start)}
+                        setEnd = {(end) => setSeasonEnd(end)}
+                    />
                 </Row>
                 {matches.length == 0 || players.length == 0 ? (
                     /* if no matches yet or if there are matches but no players */

--- a/front-end/src/components/SeasonSelector.js
+++ b/front-end/src/components/SeasonSelector.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+
+const SeasonSelector = ({ setStart, setEnd }) => {
+  const [selectedSeason, setSelectedSeason] = useState('');
+  const options = [
+    { label: '2023-2024', value: '2023-09-01, 2024-08-31'  },
+    { label: '2022-2023', value: '2022-09-01, 2023-08-31'  },
+    { label: '2021-2022', value: '2021-09-01, 2022-08-31'  },
+    { label: 'ALL', value:  '2000-09-01, 3000-09-01'  },
+  ];
+
+  const handleSeasonChange = (event) => {
+    setSelectedSeason(event.target.value)
+    let start = event.target.value.substring(0, 10);
+    let end = event.target.value.substring(12, 22);
+    setStart(start)
+    setEnd(end)
+  };
+
+
+  return (
+    <div>
+      <select onChange={handleSeasonChange} value={selectedSeason}>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default SeasonSelector;


### PR DESCRIPTION
soft reset for elo, rankings, based on season (sept 1 20xx -> aug 31 20xx + 1)

changes: 

BE: 
added arguments to filter by  start date  and end date on 
1. match endpoint
2. ranking endpoint
3. elo endpoint

FE: 
1. added new season selector component
- manipulates state (start and end)
2. updated rankings, elo, and results page to filter by season

Devops:
minor script changes
env var change for remote development 

things to do:
make better UI design for new drop down 
BE: - could maybe create a helper function to handle getting the start and end args
FE: use global state from app context instead of local state per component