### PR TITLE
Hide old players (with eleg. year < 0)

### DIFF
--- a/front-end/src/Contexts/AppContext.js
+++ b/front-end/src/Contexts/AppContext.js
@@ -10,6 +10,7 @@ export const AppContext = React.createContext('')
 
 const useApp = () => {
     const [players, setPlayers] = useState([]);
+    const [activePlayers, setActivePlayers] = useState([]);
     const [categories, setCategories] = useState([]);
     const [singlesRankings, setSinglesRankings] = useState([]);
     const [doublesRankings, setDoublesRankings] = useState([]);
@@ -23,8 +24,10 @@ const useApp = () => {
         fetch(PlayersUrl, { method: 'GET', headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' } })
             .then(res => res.json())
             .then(data => {
+                console.error(data)
                 data.sort((a, b) => (a.first_name > b.first_name) ? 1 : ((b.first_name > a.first_name) ? -1 : 0));
                 setPlayers(data);
+                setActivePlayers(data.filter((p) => p.elegible_year >= 0));
             });
 
         fetch(CategoryUrl, { method: 'GET' })
@@ -70,6 +73,7 @@ const useApp = () => {
         //constants across app
         categories,
         players,
+        activePlayers,
         singlesRankings,
         doublesRankings,
         mixedRankings,

--- a/front-end/src/Forms/DoublesForm.js
+++ b/front-end/src/Forms/DoublesForm.js
@@ -7,7 +7,7 @@ import * as ReactDOM from 'react-dom';
 const DoublesForm = () => {
     const [bannerMessage, setBannerMessage] = useState('');
 
-    const { players, categories } = useContext(AppContext);
+    const { activePlayers, categories } = useContext(AppContext);
 
     const [matchObj, setMatchObj] = useState({
         event: 'Doubles',
@@ -18,6 +18,10 @@ const DoublesForm = () => {
         score: [0, 0, 0, 0, 0, 0],
         category: ''
     })
+
+
+
+
 
     async function postResults(e) {
         e.preventDefault();
@@ -105,13 +109,13 @@ const DoublesForm = () => {
                         <Col>
                             <Form.Select name='player1Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                         <Col>
                             <Form.Select name='player2Id' onChange={handleMatchDataChange}> 
                                 <option>Select</option>
-                                {players.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                     </Row>
@@ -125,13 +129,13 @@ const DoublesForm = () => {
                         <Col>
                             <Form.Select name='player3Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                         <Col>
                             <Form.Select name='player4Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                     </Row>

--- a/front-end/src/Forms/MixedForm.js
+++ b/front-end/src/Forms/MixedForm.js
@@ -7,7 +7,7 @@ import * as ReactDOM from 'react-dom';
 const MixedForm = () => {
     const [bannerMessage, setBannerMessage] = useState('');
 
-    const { players, categories } = useContext(AppContext);
+    const { activePlayers, categories } = useContext(AppContext);
 
     const [matchObj, setMatchObj] = useState({
         event: 'Mixed',
@@ -104,14 +104,14 @@ const MixedForm = () => {
                             <Form.Label>Male</Form.Label>
                             <Form.Select name='player1Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.filter(p => p.sex === 'M').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.filter(p => p.sex === 'M').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                         <Col>
                             <Form.Label>Female</Form.Label>
                             <Form.Select name='player2Id' onChange={handleMatchDataChange}> 
                                 <option>Select</option>
-                                {players.filter(p => p.sex === 'F').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.filter(p => p.sex === 'F').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                     </Row>
@@ -126,14 +126,14 @@ const MixedForm = () => {
                             <Form.Label>Male</Form.Label>
                             <Form.Select name='player3Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.filter(p => p.sex === 'M').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.filter(p => p.sex === 'M').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                         <Col>
                             <Form.Label>Female</Form.Label>
                             <Form.Select name='player4Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.filter(p => p.sex === 'F').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.filter(p => p.sex === 'F').map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                     </Row>

--- a/front-end/src/Forms/SinglesForm.js
+++ b/front-end/src/Forms/SinglesForm.js
@@ -9,7 +9,7 @@ const SinglesForm = (formRef) => {
 
     const [show, setShow] = useState(true);
 
-    const { categories, players } = useContext(AppContext);
+    const { categories, activePlayers } = useContext(AppContext);
 
     const [matchObj, setMatchObj] = useState({
         event: 'Singles',
@@ -106,13 +106,13 @@ const SinglesForm = (formRef) => {
                         <Col>
                             <Form.Select name='player1Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                         <Col>
                             <Form.Select name='player2Id' onChange={handleMatchDataChange}>
                                 <option>Select</option>
-                                {players.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
+                                {activePlayers.map((p, i) => <option key={i} value={p.id}>{p.first_name} {p.last_name}</option>)}
                             </Form.Select>
                         </Col>
                     </Row>


### PR DESCRIPTION
Hides old players from the dropdown options when reporting matches to decrease clutter. 